### PR TITLE
Delay world map battle menu until move completion

### DIFF
--- a/Assets/Scripts/CharacterController.cs
+++ b/Assets/Scripts/CharacterController.cs
@@ -106,7 +106,7 @@ public class CharacterController : MonoBehaviour
             }
         }
 
-        // Wenn der Spieler sein Ziel erreicht hat, wird das Aktionsmenü angezeigt.
+        // Wenn der Spieler sein Ziel erreicht hat, werden passende Menüs angezeigt.
         if (!isEnemy && playerMovePending && Vector3.Distance(transform.position, moveTarget) < 0.01f)
         {
             playerMovePending = false;
@@ -114,7 +114,14 @@ public class CharacterController : MonoBehaviour
 
             if (GameManager.instance.activePlayer == this)
             {
-                ActionMenu.instance.ShowMenu();
+                if (OpenMenu.instance != null)
+                {
+                    OpenMenu.instance.ShowBattleMenus();
+                }
+                else if (ActionMenu.instance != null)
+                {
+                    ActionMenu.instance.ShowMenu();
+                }
             }
         }
 

--- a/Assets/Scripts/OpenMenu.cs
+++ b/Assets/Scripts/OpenMenu.cs
@@ -1,15 +1,14 @@
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
-using UnityEngine.InputSystem;
 using UnityEngine.SceneManagement;
 
 /// <summary>
-/// Steuert das Öffnen von Menüs und den Übergang in die Kampfszene.
+/// Steuert das Ã–ffnen von MenÃ¼s und den Ãœbergang in die Kampfszene.
 /// </summary>
 public class OpenMenu : MonoBehaviour
 {
-    /// <summary>Singleton-Instanz des Menüs.</summary>
+    /// <summary>Singleton-Instanz des MenÃ¼s.</summary>
     public static OpenMenu instance;
 
     private void Awake()
@@ -17,22 +16,16 @@ public class OpenMenu : MonoBehaviour
         instance = this;
     }
 
-    private void OnTriggerEnter(Collider other)
-    {
-        // Beim Betreten des Triggers werden die Kampfmenüs eingeblendet.
-        OpenMenu.instance.ShowBattleMenus();
-    }
-
-    /// <summary>Wurzelobjekt für das Kampfmenü.</summary>
+    /// <summary>Wurzelobjekt fÃ¼r das KampfmenÃ¼.</summary>
     public GameObject battleMenu;
 
-    /// <summary>Versteckt sämtliche Menüs.</summary>
+    /// <summary>Versteckt sÃ¤mtliche MenÃ¼s.</summary>
     public void HideMenus()
     {
         battleMenu.SetActive(false);
     }
 
-    /// <summary>Blendet das Kampfmenü ein.</summary>
+    /// <summary>Blendet das KampfmenÃ¼ ein.</summary>
     public void ShowBattleMenus()
     {
         battleMenu.SetActive(true);


### PR DESCRIPTION
## Summary
- Remove trigger-based auto display of battle/cancel menu
- Show world map battle menu only after character moves to a selected point

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bafce08be88328ae1d43aa1a6ec141