### PR TITLE
Avoid unassigned battle menu reference

### DIFF
--- a/Assets/Scenes/WorldMap.unity
+++ b/Assets/Scenes/WorldMap.unity
@@ -735,9 +735,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 8800812fa6ef15741b4dbbd9b4586dd8, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  battleMenu: {fileID: 0}
+  m_Name:
+  m_EditorClassIdentifier:
 --- !u!1001 &958804129
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1740,9 +1739,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 8800812fa6ef15741b4dbbd9b4586dd8, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  battleMenu: {fileID: 1039823538}
+  m_Name:
+  m_EditorClassIdentifier:
 --- !u!1 &1786032837
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/OpenMenu.cs
+++ b/Assets/Scripts/OpenMenu.cs
@@ -16,19 +16,22 @@ public class OpenMenu : MonoBehaviour
         instance = this;
     }
 
-    /// <summary>Wurzelobjekt für das Kampfmenü.</summary>
-    public GameObject battleMenu;
-
     /// <summary>Versteckt sämtliche Menüs.</summary>
     public void HideMenus()
     {
-        battleMenu.SetActive(false);
+        if (BattleMenu.instance != null)
+        {
+            BattleMenu.instance.Hide();
+        }
     }
 
     /// <summary>Blendet das Kampfmenü ein.</summary>
     public void ShowBattleMenus()
     {
-        battleMenu.SetActive(true);
+        if (BattleMenu.instance != null)
+        {
+            BattleMenu.instance.Show();
+        }
     }
 
     /// <summary>Wechselt in die Kampfszene.</summary>


### PR DESCRIPTION
## Summary
- Remove inspector-based battle menu reference and use BattleMenu singleton for showing and hiding menus
- Clean up scene to drop obsolete battleMenu assignments

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68baff3b0b58832880e87c635700160b