### PR TITLE
Hide battle menu until player reaches move point

### DIFF
--- a/Assets/Scripts/OpenMenu.cs
+++ b/Assets/Scripts/OpenMenu.cs
@@ -14,6 +14,7 @@ public class OpenMenu : MonoBehaviour
     private void Awake()
     {
         instance = this;
+        HideMenus();
     }
 
     /// <summary>Wurzelobjekt für das Kampfmenü.</summary>


### PR DESCRIPTION
## Summary
- Hide battle UI on scene load so Battle and Cancel buttons start inactive

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb0955fe908328addf10bf4c122648